### PR TITLE
Prepend SAN cert variable with --domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ Example Playbook when requesting certificate with SAN
 
     - hosts: servers
       roles:
-         - { role: CSCfi.certbot, sectigo_cron: '30 6 * * * certbot renew --post-hook "systemctl reload httpd"', sectigo_san_domains: " --domain server1.domain.example --domain server2.domain.example"}
-         
+         - { role: CSCfi.certbot, sectigo_cron: '30 6 * * * certbot renew --post-hook "systemctl reload httpd"', sectigo_san_domains: "server1.domain.example,server2.domain.example"}
 
 License
 -------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
     - name: certbot | cron.d | setup
       copy: content="{{ sectigo_cron }}" dest=/etc/cron.d/certbot mode=755 owner=root group=root
 
-    - shell: certbot certonly --apache --server https://acme.sectigo.com/v2/OV --non-interactive --agree-tos --domain {{ sectigo_domains }} {{ sectigo_san_domains }}
+    - shell: certbot certonly --apache --server https://acme.sectigo.com/v2/OV --non-interactive --agree-tos --domain {{ sectigo_domains }} --domain {{ sectigo_san_domains }}
       when: sectigo_san_domains is defined
 
     - shell: certbot certonly --apache --server https://acme.sectigo.com/v2/OV --non-interactive --agree-tos --domain {{ sectigo_domains }} 


### PR DESCRIPTION
Readme instructs

`sectigo_san_domains: " --domain server1.domain.example --domain server2.domain.example"`

IMO this is slightly bad practice as it is forcing the user to mix an interface with data, instead of just providing data.

Proposing to prepend the extra --domain instead, which should be OK according to The Fine Manual:


```
          usage:
            certbot [SUBCOMMAND] [options] [-d DOMAIN] [-d DOMAIN] ...
```
