### PR TITLE
Documentation and legibility fixes; less is more

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 Role Name
 =========
 
-This role installs certbot on RedHat machines (can be extended other distros as well). This role is created taken sectigo on account with current limitations with agreement and apis.
+This role installs certbot on RedHat machines (can be extended other distros as
+well). This role is created taken sectigo on account with current limitations
+with agreement and apis.
 
 Role Variables
 --------------
 
-When using vault, use 'vault_sectigo_' prefix with variables otherwise just 'sectigo_' prefix is used with variables (except with variable sectigo_domains which is not vaulted variable).
-```
-sectigo_domains: Which domain(s) to request if needed.
-sectigo_san_domains: If SAN domain(s) is needed on certificate.
-```
+When using vault, use 'vault_sectigo_' prefix with variables otherwise just
+'sectigo_' prefix is used with variables (except with variable sectigo_domains
+which is not vaulted variable).
+
+For variable content examples, see defaults/main.yml.
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -8,29 +8,8 @@ Role Variables
 
 When using vault, use 'vault_sectigo_' prefix with variables otherwise just 'sectigo_' prefix is used with variables (except with variable sectigo_domains which is not vaulted variable).
 ```
-vault_sectigo_account: Account directory under /etc/letsencrypt/accounts/acme.sectigo.com/v2/OV/
-
-vault_sectigo_meta:
-  creation_dt: 
-  creation_host: 
-
-vault_sectigo_regr:
-  body: {}
-  uri: API uri
-
-vault_sectigo_private_key:
-  e: AQAB
-  d:
-  n:
-  q:
-  p:
-  kty: RSA
-  qi:
-  dp:
-  dq:
-
 sectigo_domains: Which domain(s) to request if needed.
-sectigo_san_domains: If SAN domains is needed on certificate.
+sectigo_san_domains: If SAN domain(s) is needed on certificate.
 ```
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,14 @@
 # sectigo_private_key: "{{ vault_sectigo_private_key }}"
 
 sectigo_domains: "{{ ansible_fqdn }}"
+#sectigo_san_domains:  foo.bar,bar.foo
+#sectigo_emailAddress: contact@org
+
+#sectigo_eab_kid:      received_from_provider
+#sectigo_eab_hmac_key: received_from_provider
 
 # example with hook:
 # sectigo_cron: '30 6 * * * certbot renew --post-hook "systemctl reload httpd"'
+# example with proxy:
+# sectigo_cron: '30 6 * * * http_proxy=http://foobar.foo:3123 certbot renew'
 sectigo_cron: '30 6 * * * certbot renew'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # defaults file for ansible-role-certbot
 
-sectigo_domains: "{{ ansible_fqdn }}"
-#sectigo_san_domains:  foo.bar,bar.foo
+sectigo_domains:       "{{ ansible_fqdn }}"
+#sectigo_san_domains:  server1.domain.example,server2.domain.example
 #sectigo_emailAddress: contact@org
 
 #sectigo_eab_kid:      received_from_provider

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,6 @@
 ---
 # defaults file for ansible-role-certbot
 
-# sectigo_account: "{{ vault_sectigo_account }}"
-# sectigo_meta: "{{ vault_sectigo_meta }}"
-# sectigo_regr: "{{ vault_sectigo_regr }}"
-# sectigo_private_key: "{{ vault_sectigo_private_key }}"
-
 sectigo_domains: "{{ ansible_fqdn }}"
 #sectigo_san_domains:  foo.bar,bar.foo
 #sectigo_emailAddress: contact@org

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,22 +35,9 @@
 
     - shell: certbot certonly --apache --server https://acme.sectigo.com/v2/OV --non-interactive --agree-tos --domain {{ sectigo_domains }} 
       when: sectigo_san_domains is not defined
-
-  when: (sectigo_eab_kid is defined) and (sectigo_eab_hmac_key is defined) and (sectigo_emailAddress is defined) and (sectigo_domains is defined) and (not isRegistered.stat.exists)
-
-# - name: Create directory structure
-#   file:
-#     path: "/etc/letsencrypt/{{ item }}"
-#     owner: root
-#     group: root
-#     mode: 0755
-#     recurse: yes
-#     state: directory
-#   with_items: ["accounts", "accounts/acme.sectigo.com", "accounts/acme.sectigo.com/v2", "accounts/acme.sectigo.com/v2/OV", "accounts/acme.sectigo.com/v2/OV/{{ sectigo_account }}"]
-
-# - copy: content="{{ sectigo_meta|to_json }}" dest=/etc/letsencrypt/accounts/acme.sectigo.com/v2/OV/{{ sectigo_account }}/meta.json
-
-# - copy: content="{{ sectigo_private_key|to_json }}" dest=/etc/letsencrypt/accounts/acme.sectigo.com/v2/OV/{{ sectigo_account }}/private_key.json
-
-# - copy: content="{{ sectigo_regr|to_json }}" dest=/etc/letsencrypt/accounts/acme.sectigo.com/v2/OV/{{ sectigo_account }}/regr.json
-
+  when:
+    - sectigo_eab_kid is defined
+    - sectigo_eab_hmac_key is defined
+    - sectigo_emailAddress is defined
+    - sectigo_domains is defined
+    - not isRegistered.stat.exists


### PR DESCRIPTION
- Since account/meta/regr/privkey variables don't seem to be in use, remove them.
- Add variable example defaults for relevant variables
- Add example of using a proxy in cronjob
- Expand the block condition for registration + cert retrieval into a list. This block should probably be carved into separate assertions, but leaving that for another PR.